### PR TITLE
Fix division by zero when all writes has failed

### DIFF
--- a/pkg/operations/normal.go
+++ b/pkg/operations/normal.go
@@ -59,6 +59,10 @@ func (ns *NormalStatsOneThread) FillInStats(times []time.Duration) {
 func AggregateStats(stats []NormalStatsOneThread, totalTime time.Duration) NormalStatsOneThread {
 	var t NormalStatsOneThread
 	len := len(stats)
+	if len == 0 {
+		return t
+	}
+
 	for _, s := range stats {
 		t.Average += s.Average
 		if t.Minimum == 0 || s.Minimum < t.Minimum {


### PR DESCRIPTION

```
// ......

writeSomeBatches error: IO error: No space left on device: While appending to file: /data/engine-rocksdb/journals/000982.log: No space left on device
panic: runtime error: integer divide by zero

goroutine 1 [running]:
github.com/arangodb/feed/pkg/operations.AggregateStats({0x0?, 0xa5def0?, 0xc0001b8000?}, 0x4cf4dd?)
        /home/nikita/go/pkg/mod/github.com/arangodb/feed@v0.9.1/pkg/operations/normal.go:79 +0x205
github.com/arangodb/feed/pkg/operations.writeSomeBatchesParallel.func2(0x929d5e7d7a, 0x1)
        /home/nikita/go/pkg/mod/github.com/arangodb/feed@v0.9.1/pkg/operations/normal.go:1537 +0x73
github.com/arangodb/feed/pkg/operations.RunParallel(0x10, 0x5, {0x993aa5, 0x10}, 0xc0000ad308, 0xc0000f9a38)
        /home/nikita/go/pkg/mod/github.com/arangodb/feed@v0.9.1/pkg/operations/operations.go:222 +0x1e2
// ......
```