### PR TITLE
Make --protocol=http1 default, better error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Usage:
    [flags]
 
 Flags:
-      --endpoints strings      Endpoint of server where data should be written. (default [http://localhost:8529])
+      --endpoints strings      Endpoint of server where data should be written. (default http://localhost:8529)
       --execute string         Filename of program to execute. (default "doit.feed")
   -h, --help                   help for this command
       --jsonOutputFile string  File name of JSON report on performance which is written.

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func init() {
 	flags.StringVar(&config.Username, "username", "root", "User name for database access.")
 	flags.StringVar(&config.Password, "password", "", "Password for database access.")
 	flags.StringVar(&ProgName, "execute", "doit.feed", "Filename of program to execute.")
-	flags.StringVar(&config.Protocol, "protocol", "vst", "Protocol (http1, http2, vst)")
+	flags.StringVar(&config.Protocol, "protocol", "http1", "Protocol (http1, http2, vst)")
 	flags.StringVar(&config.JSONOutput, "jsonOutputFile", "feed.json", "Filename for JSON result output.")
 	flags.IntVar(&config.MetricsPort, "metricsPort", 8888, "Metrics port (0 for no metrics)")
 	flags.IntVar(&MoreWords, "moreWords", 0, "Number of additional random terms in long word list")

--- a/pkg/feedlang/feedlang.go
+++ b/pkg/feedlang/feedlang.go
@@ -317,6 +317,10 @@ func parserRecursion(lines []string, pos *int, depth int) (Program, error) {
 		return nil, fmt.Errorf("No Maker for first word %s in line %d of input in depth %d", cmd, *pos+1, depth)
 	}
 	prog, err := maker(args, *pos+1)
+  if err != nil {
+    fmt.Errorf("Error in maker: %v", err)
+    return nil, fmt.Errorf("Error in maker: %v", err)
+  }
 	st, en := prog.Lines()
 	prog.SetSource(lines[st-1 : en])
 	if err != nil {


### PR DESCRIPTION
Small fixes:

- **Default --protocol http1.**
- **Better error reporting.**
